### PR TITLE
Add Wizard message parameter to enforce deterministic deployments with reason

### DIFF
--- a/src/lib/models/ui.ts
+++ b/src/lib/models/ui.ts
@@ -24,6 +24,7 @@ export type GlobalState = {
     source?: CompilationFileSources | null | SourceWithTarget,
     version?: string,
     data?: CompilationResult | null,
+    enforceDeterministicReason?: string,
   }
   form: {
     network?: string | TenantNetworkResponse;

--- a/src/lib/wizard/components/Deploy.svelte
+++ b/src/lib/wizard/components/Deploy.svelte
@@ -54,7 +54,8 @@
   let enforceDeterministic = $derived.by(() => {
     const selectedMultisig = globalState.form.approvalType === 'existing' && isMultisig(globalState.form.approvalProcessSelected?.viaType);
     const toCreateMultisig = globalState.form.approvalType === 'new' && isMultisig(globalState.form.approvalProcessToCreate?.viaType);
-    return selectedMultisig || toCreateMultisig;
+    const hasReasonMessage = globalState.contract?.enforceDeterministicReason !== undefined;
+    return selectedMultisig || toCreateMultisig || hasReasonMessage;
   });
 
   const deploymentUrl = $derived(
@@ -97,6 +98,10 @@
 
     if (globalState.contract?.target && compilationResult) {
       inputs = getConstructorInputsWizard(globalState.contract.target, compilationResult.output.contracts);
+
+      // Clear deploy status messages
+      successMessage = "";
+      errorMessage = "";
     }
     isCompiling = false;
   }
@@ -226,7 +231,11 @@
     }
 
     if ((isDeterministic || enforceDeterministic) && !salt) {
-      displayMessage("Salt is required", "error");
+      if (globalState.contract?.enforceDeterministicReason) {
+        displayMessage(`Salt is required: ${globalState.contract.enforceDeterministicReason}`, "error");
+      } else {
+        displayMessage("Salt is required", "error");
+      }
       return;
     }
 

--- a/src/lib/wizard/index.ts
+++ b/src/lib/wizard/index.ts
@@ -4,6 +4,7 @@ import { globalState } from "$lib/state/state.svelte";
 export interface DefenderDeployMessage {
   kind: 'oz-wizard-defender-deploy';
   sources: ContractSources;
+  enforceDeterministicReason?: string;
 }
 
 export const initWizardPlugin = () => {
@@ -18,7 +19,8 @@ function listenToContracts() {
         source: {
           sources: e.data.sources,
         },
-        target: getMainContractName(e.data.sources) 
+        target: getMainContractName(e.data.sources),
+        enforceDeterministicReason: e.data.enforceDeterministicReason,
       };
     }
   });


### PR DESCRIPTION
Some scenarios from Wizard require the user to deploy the contract deterministically so that they have the same address on different chains.

For these scenarios, we want to pass a message to the Defender Deploy Plugin's iframe so it does the following:
- Requires deterministic deployments
- If the user does not provide a Salt, print the reason why deterministic deployments are required for this contract.
- If a recompilation occurs (meaning the user modified the contract), clear any previous success or error message since those are no longer relevant.

Example of how this looks (see error message on the right):
![Screenshot 2025-02-14 at 1 45 47 PM](https://github.com/user-attachments/assets/81bb0a06-6344-42ce-b8d6-247cbd3d45fc)
