### PR TITLE
Wizard: Add tip to set explorer API key for network

### DIFF
--- a/src/lib/wizard/components/Network.svelte
+++ b/src/lib/wizard/components/Network.svelte
@@ -7,6 +7,7 @@
   import type { DropdownItem } from "$lib/models/ui";
   import { globalState } from "$lib/state/state.svelte";
   import Dropdown from "./shared/Dropdown.svelte";
+  import Message from "./shared/Message.svelte";
 
   type Props = {
     onSelected: (network: string) => void;
@@ -52,3 +53,12 @@
   on:select={(e) => onNetworkSelect(e.detail)}
   defaultItem={globalState.form.network ? networkToDropdownItem(globalState.form.network) : undefined}
 />
+
+<div class="alert alert-success d-flex align-items-center mt-2">
+<div class="mt-2">
+  <Message
+    message="Tip: Ensure you have an Explorer API Key set in your <u><a href='https://defender.openzeppelin.com/#/deploy' target='_blank'>Deploy Environment</a></u> for this network to allow the contract to be verified automatically."
+    type="tip"
+  />
+</div>
+</div>

--- a/src/lib/wizard/components/shared/Message.svelte
+++ b/src/lib/wizard/components/shared/Message.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   type Props = {
     message: string;
-    type: 'success' | 'error' | 'warn' | 'info' | 'loading';
+    type: 'success' | 'error' | 'warn' | 'info' | 'loading' | 'tip';
   };
 
   let { message, type }: Props = $props();
@@ -26,6 +26,11 @@
   <div class="flex flex-row items-center gap-2">
     <i class={`fa fa-info-circle text-blue-600`}></i>
     <div class="text-xs text-blue-600">{@html message}</div>
+  </div>
+{:else if type === 'tip'}
+  <div class="flex flex-row items-center gap-2">
+    <i class={`fa fa-lightbulb-o text-lime-600`}></i>
+    <div class="text-xs text-gray-600">{@html message}</div>
   </div>
 {:else if type === 'loading'}
   <div class="flex flex-row items-center gap-2">


### PR DESCRIPTION
Adds a tip in the network selection form, to remind users to set an explorer API key so that the contract can be verified automatically.

Example:
![Screenshot 2025-02-24 at 8 00 14 PM](https://github.com/user-attachments/assets/7b94e5d9-6c0b-4872-bbc8-e8df1bbb0f14)

Fixes PLAT-6295