### PR TITLE
Update Wizard's get API key link

### DIFF
--- a/src/lib/wizard/components/Configuration.svelte
+++ b/src/lib/wizard/components/Configuration.svelte
@@ -69,6 +69,9 @@
 </script>
 
 <div class="flex flex-col gap-2">
+  <div class="flex flex-row">
+    <button onclick={handleGetApiKey} class="text-xs text-blue-600 font-bold">Get API Key from OpenZeppelin Defender</button>
+  </div>
   <div class="flex flex-row justify-between">
     <div>
       <label class="text-sm" for="apiKey">API Key</label>
@@ -77,9 +80,6 @@
         title="Get your API key from the Defender Dashboard"
       ></i>
     </div>
-    <button onclick={handleGetApiKey} class="text-xs text-blue-600 font-bold"
-      >Get API Key</button
-    >
   </div>
   <Input
     bind:value={apiKey}


### PR DESCRIPTION
Changes the Wizard deploy plugin's "Get API Key" link to specifically mention OpenZeppelin Defender, and moved it above "API Key" label to avoid having too much text in one line.

(This allows us to change the "Deploy with Defender" label in Wizard to simply "Deploy", and have the context about OpenZeppelin Defender within this plugin.)

![Screenshot 2025-03-17 at 8 00 23 PM](https://github.com/user-attachments/assets/57bea5bc-04d0-4a35-a734-cd6534b01b53)

