### PR TITLE
filter out netowrks for which deployment using Defender is not supported

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 		"vite": "^5.0.3"
 	},
 	"dependencies": {
-		"@openzeppelin/defender-sdk": "^2.4.0",
+		"@openzeppelin/defender-sdk": "^2.5.0",
 		"@remixproject/plugin": "^0.3.38",
 		"@remixproject/plugin-api": "^0.3.38",
 		"@remixproject/plugin-iframe": "^0.3.38",

--- a/src/lib/defender/index.ts
+++ b/src/lib/defender/index.ts
@@ -22,12 +22,12 @@ export const listApiKeyPermissions = async (credentials: Credentials) => {
 
 export const listNetworks = async (credentials: Credentials) => {
   const client = getClient(credentials);
-  const [networks, forkedNetworks, privateNetworks] = await Promise.all([
-    client.network.listSupportedNetworks(),
+  
+  return (await Promise.all([
+    client.network.listSupportedNetworks({ networkType: "deploy" }),
     client.network.listForkedNetworks(),
     client.network.listPrivateNetworks(),
-  ]);
-  return [...networks, ...forkedNetworks, ...privateNetworks];
+  ])).flat();
 }
 
 export const listApprovalProcesses = async (credentials: Credentials) => {


### PR DESCRIPTION
Use network type=deploy list query on sdk to get only networks for which deploying with Defender is supported

Note: 
- awaiting SDK release