### PR TITLE
Fix iframe loading on Firefox

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -15,18 +15,22 @@
 			return;
 		}
 
-		const ancestorOrigin = document.location.ancestorOrigins[0];
+		const referrer = document.referrer; // Available through Wizard. Empty string through Remix.
+		const ancestorOrigins = document.location.ancestorOrigins; // undefined on Firefox
+
+		const parentUrl = ancestorOrigins?.[0] || referrer;
 
 		if (dev) {
 			// add desired behaviour for dev mode.
 		}
 
 		// in case we are developing locally, we want to use the wizard as the parent..
-		if (ancestorOrigin.includes("wizard") || ancestorOrigin.includes("localhost")) {
+		if (parentUrl.includes("wizard") || parentUrl.includes("localhost")) {
 			return parent = 'wizard';
 		}
 
-		if (ancestorOrigin.includes("remix.ethereum")) {
+		// Remix on Firefox leads to empty parentUrl due to ancestorOrigins and referrer being unavailable.
+		if (parentUrl.includes("remix.ethereum") || !parentUrl) {
 			return parent = 'remix';
 		}
 


### PR DESCRIPTION
Fixes #45 

This plugin is intended to be embedded in an iframe and uses the parent's URL to determine if it should load the Remix or Wizard version.

It used `document.location.ancestorOrigins` which is available on most browsers except Firefox.  

As a solution, when this is not available, we can use `document.referrer` if the parent iframe allows cross-origin referrer to be passed through (this is allowed in Wizard, but not Remix since it has `<iframe sandbox="... allow-same-origin">`

This PR causes `document.referrer` to be used as a fallback to get the parent URL, and infers Remix if it is still unknown due to the above reasons (which only occurs on Remix+Firefox)