### PR TITLE
Add backup chain id getter, display clear error message on failing to switch wallet, remove remix log

### DIFF
--- a/src/lib/ethereum/index.ts
+++ b/src/lib/ethereum/index.ts
@@ -1,9 +1,12 @@
-import { type Eip1193Provider, BrowserProvider, ContractFactory } from 'ethers';
-import { type NetworkResponse, type TenantNetworkResponse } from "$lib/models/network";
-import type { DeployContractResult } from '$lib/models/ethereum';
+import { type Eip1193Provider, BrowserProvider, ContractFactory } from "ethers";
+import {
+  type NetworkResponse,
+  type TenantNetworkResponse,
+} from "$lib/models/network";
+import type { DeployContractResult } from "$lib/models/ethereum";
 
 function getEthereum(): Eip1193Provider {
-  if (!window.ethereum) throw new Error('Injected provider not found');
+  if (!window.ethereum) throw new Error("Injected provider not found");
   return window.ethereum;
 }
 
@@ -11,10 +14,10 @@ async function getCurrentWalletNetwork() {
   const ethereum = getEthereum();
 
   try {
-    return await ethereum.request({ method: 'eth_chainId' });
+    return await ethereum.request({ method: "eth_chainId" });
   } catch (err) {
     try {
-      const netVersion = await ethereum.request({ method: 'net_version' });
+      const netVersion = await ethereum.request({ method: "net_version" });
       return `0x${parseInt(netVersion as string, 10).toString(16)}`;
     } catch {
       throw new Error(`Error switching network: ${(err as Error).message}`);
@@ -22,38 +25,50 @@ async function getCurrentWalletNetwork() {
   }
 }
 
-/**
- * Switches the user's wallet to the target network.
- * 
- * @param network target network to switch to.
- */
-export async function switchToNetwork(network: NetworkResponse | TenantNetworkResponse) {
-  if (!network.chainId) throw new Error(`Invalid network: ${network}`);
-
+async function requestWalletSwitchChain(
+  network: NetworkResponse | TenantNetworkResponse
+) {
   const ethereum = getEthereum();
-
-  const currentChainIdHex = await getCurrentWalletNetwork()
-  if (parseInt(currentChainIdHex, 16) === network.chainId) return;
 
   try {
     await ethereum.request({
-    method: 'wallet_switchEthereumChain',
-    params: [{ chainId: `0x${network.chainId.toString(16)}` }],
-  });
+      method: "wallet_switchEthereumChain",
+      params: [{ chainId: `0x${network.chainId.toString(16)}` }],
+    });
   } catch {
-    throw new Error(`Could not automatically switch to ${network.name}, please manually ensure that the appropriate network ${network.name} is selected on your wallet (multiple wallet extensions can also prevent proper deployment with injected provider)`)
+    throw new Error(
+      `Could not automatically switch to ${network.name}. Ensure the appropriate network ${network.name} is selected on your wallet (multiple wallet extensions can also prevent proper deployment with injected provider)`
+    );
   }
-};
+}
 
 /**
- * 
+ * Switches the user's wallet to the target network.
+ *
+ * @param network target network to switch to.
+ */
+export async function switchToNetwork(
+  network: NetworkResponse | TenantNetworkResponse
+) {
+  if (!network.chainId) throw new Error(`Invalid network: ${network}`);
+
+  const currentChainIdHex = await getCurrentWalletNetwork();
+  if (parseInt(currentChainIdHex, 16) === network.chainId) return;
+
+  await requestWalletSwitchChain(network);
+}
+
+/**
+ *
  * @param deployTxData contract bytecode generated from contract compilation.
  * @returns tx hash
  */
-export async function deployContract(deployTxData: string): Promise<DeployContractResult> {
+export async function deployContract(
+  deployTxData: string
+): Promise<DeployContractResult> {
   const ethereum = getEthereum();
-  
-  await ethereum.request({ method: 'eth_requestAccounts' });
+
+  await ethereum.request({ method: "eth_requestAccounts" });
 
   const provider = new BrowserProvider(ethereum);
   const signer = await provider.getSigner();
@@ -61,7 +76,7 @@ export async function deployContract(deployTxData: string): Promise<DeployContra
 
   const contract = await factory.deploy();
   const recipt = await contract.deploymentTransaction()?.wait();
-  if (!recipt) throw new Error('Deployment transaction failed');
+  if (!recipt) throw new Error("Deployment transaction failed");
 
   const contractAddress = await contract.getAddress();
   const senderAddress = await signer.getAddress();

--- a/src/lib/ethereum/index.ts
+++ b/src/lib/ethereum/index.ts
@@ -1,11 +1,25 @@
 import { type Eip1193Provider, BrowserProvider, ContractFactory } from 'ethers';
 import { type NetworkResponse, type TenantNetworkResponse } from "$lib/models/network";
 import type { DeployContractResult } from '$lib/models/ethereum';
-import { log } from '$lib/remix/logger';
 
 function getEthereum(): Eip1193Provider {
   if (!window.ethereum) throw new Error('Injected provider not found');
   return window.ethereum;
+}
+
+async function getCurrentWalletNetwork() {
+  const ethereum = getEthereum();
+
+  try {
+    return await ethereum.request({ method: 'eth_chainId' });
+  } catch (err) {
+    try {
+      const netVersion = await ethereum.request({ method: 'net_version' });
+      return `0x${parseInt(netVersion as string, 10).toString(16)}`;
+    } catch {
+      throw new Error(`Error switching network: ${(err as Error).message}`);
+    }
+  }
 }
 
 /**
@@ -18,16 +32,17 @@ export async function switchToNetwork(network: NetworkResponse | TenantNetworkRe
 
   const ethereum = getEthereum();
 
-  // ignore if user is already connected to target network.
-  const current = await ethereum.request({ method: 'eth_chainId' });
-  if (parseInt(current, 16) === network.chainId) return;
+  const currentChainIdHex = await getCurrentWalletNetwork()
+  if (parseInt(currentChainIdHex, 16) === network.chainId) return;
 
-  log("[Defender Deploy] Switching network...");
-
-  await ethereum.request({
+  try {
+    await ethereum.request({
     method: 'wallet_switchEthereumChain',
     params: [{ chainId: `0x${network.chainId.toString(16)}` }],
   });
+  } catch {
+    throw new Error(`Could not automatically switch to ${network.name}, please manually ensure that the appropriate network ${network.name} is selected on your wallet (multiple wallet extensions can also prevent proper deployment with injected provider)`)
+  }
 };
 
 /**


### PR DESCRIPTION
- Add backup chain id getter when v is not working
- Display clear error message on failing to switch wallet (it can happen that having multiple wallet prevent automatic switching of chain)
- Remove remix log in Ethereum as remix is not injected in the wizard side (which also goes thought this code path) 